### PR TITLE
Adds extra WERROR setting to cmake for continuous testing

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -50,11 +50,16 @@ set(CMAKE_LIBRARY_OUTPUT_DIRECTORY "${CMAKE_BINARY_DIR}/lib")
 set(CMAKE_RUNTIME_OUTPUT_DIRECTORY "${CMAKE_BINARY_DIR}/bin")
 
 set(OPTIMIZE "-O3" CACHE STRING "Optimization level")
-if(${CMAKE_SYSTEM_NAME} MATCHES "Linux")
+if(${CMAKE_CXX_COMPILER_ID} STREQUAL "GNU")
 # Turn off excessive warnings on Linux/GCC
   set(C_CXX_FLAGS "-Wno-unused-parameter -Wno-missing-field-initializers -Wno-deprecated")
 else()
   set(C_CXX_FLAGS "-Wall -Wextra -Wno-unused-parameter -Wno-unused-local-typedef -Wno-missing-field-initializers -Wmissing-declarations -Woverloaded-virtual -pedantic-errors -Wno-deprecated")
+endif()
+if (DEFINED ENV{WERROR})
+  # Promote warnings to errors based on env variable
+  set(C_CXX_FLAGS "${C_CXX_FLAGS} -Werror")
+  message("-- Promoting warnings to errors")
 endif()
 set(CMAKE_C_FLAGS "${C_CXX_FLAGS}")
 set(CMAKE_CXX_FLAGS "${C_CXX_FLAGS} -std=c++11")


### PR DESCRIPTION
Small changes to top-level CMakelists.txt for continuous testing. This allows us to set WERROR=1 in the environment to promote warnings to errors.