### PR TITLE
Fixed segfault triggered by improper handling of generic functions

### DIFF
--- a/src/frontend/specialize_generic_functions.h
+++ b/src/frontend/specialize_generic_functions.h
@@ -13,7 +13,7 @@ namespace fir {
 
 class SpecializeGenericFunctions : public FIRVisitor {
 public:
-  SpecializeGenericFunctions(const std::vector<fir::FuncDecl::Ptr> &intrinsics)
+  SpecializeGenericFunctions(const std::vector<FuncDecl::Ptr> &intrinsics)
       : count(0), intrinsics(intrinsics) {}
 
   void specialize(Program::Ptr);
@@ -44,8 +44,11 @@ private:
 private:
   FuncMap     genericFuncs;
   FuncListMap specializedFuncs;
+  
   unsigned    count;
-  const std::vector<fir::FuncDecl::Ptr> &intrinsics;
+  std::string currentFunc;
+
+  const std::vector<FuncDecl::Ptr> &intrinsics;
 };
 
 }

--- a/test/ffi-tests.cpp
+++ b/test/ffi-tests.cpp
@@ -533,7 +533,7 @@ TEST(ffi, matrix_neg) {
   ASSERT_EQ(-10.0, (double)a(v2));
 }
 
-TEST(DISABLED_ffi, matrix_neg_generics) {
+TEST(ffi, matrix_neg_generics) {
   Set V;
   FieldRef<simit_float> a = V.addField<simit_float>("a");
   FieldRef<simit_float> b = V.addField<simit_float>("b");


### PR DESCRIPTION
Compiler should no longer segfault when generic function is specialized with sets that are declared after the declaration of the generic function.