### PR TITLE
Various bug fixes

### DIFF
--- a/src/lower/lower.cpp
+++ b/src/lower/lower.cpp
@@ -98,14 +98,14 @@ Func lower(Func func, std::ostream* os, bool time) {
   }
 #endif
 
+  // Inline function calls
+  func = rewriteCallGraph(func, inlineCalls);
+  printCallGraph("Inline Fuction Calls", func, os);
+
   // Flatten index expressions and insert temporaries
   func = rewriteCallGraph(func, (Func(*)(Func))flattenIndexExpressions);
   func = rewriteCallGraph(func, insertTemporaries);
   printCallGraph("Insert Temporaries and Flatten Index Expressions", func, os);
-
-  // Inline function calls
-  func = rewriteCallGraph(func, inlineCalls);
-  printCallGraph("Inline Fuction Calls", func, os);
 
   // Determine Storage
   func = rewriteCallGraph(func, [](Func func) -> Func {

--- a/src/rw_analysis.h
+++ b/src/rw_analysis.h
@@ -2,6 +2,8 @@
 #define SIMIT_RW_ANALYSIS
 
 #include <algorithm>
+#include <set>
+#include <vector>
 
 #include "ir_visitor.h"
 
@@ -12,6 +14,11 @@ class ReadWriteAnalysis : public IRVisitor {
 public:
   ReadWriteAnalysis(std::set<Var> vars) {
     this->vars = vars;
+  }
+
+  ReadWriteAnalysis(std::vector<Var> vars) {
+    this->vars = std::set<Var>(std::make_move_iterator(vars.begin()),
+                               std::make_move_iterator(vars.end()));
   }
 
   std::set<Var> getReads() {

--- a/test/input/system/add_blocked_inout.sim
+++ b/test/input/system/add_blocked_inout.sim
@@ -1,0 +1,48 @@
+element Vertex
+  a : float;
+  b : float;
+end
+
+element Edge
+  e : float;
+end
+
+extern V : set{Vertex};
+extern E : set{Edge}(V,V);
+
+func f(v : Vertex) -> (A : tensor[V,V](tensor[2,2](float)))
+  var I2 : tensor[2,2](float) = [1.0, 0.0; 0.0, 1.0];
+  A(v, v) = v.b * I2;
+end
+
+func g(e : Edge, v : (Vertex*2)) -> (B : tensor[V,V](tensor[2,2](float)))
+  var I2 : tensor[2,2](float) = [1.0, 0.0; 0.0, 1.0];
+  B(v(0), v(1)) = e.e * I2;
+  B(v(1), v(0)) = e.e * I2;
+end
+
+func promote(v : Vertex) -> (X : tensor[V](tensor[2](float)))
+  var unitVec : tensor[2](float) = [1.0, 1.0]';
+  X(v) = v.b * unitVec;
+end
+
+func sum_vectors(Y : tensor[V](tensor[2](float)), v : Vertex) -> (y : tensor[V](float))
+  y(v) = Y(v)(0) + Y(v)(1);
+end
+
+func scale_vector<N>(inout v : vector[N](float), c : float)
+  v = c * v;
+end
+
+export func main()
+  B = map f to V reduce +;
+  C = map g to E reduce +;
+  A = B + C;
+  var X = map promote to V;
+  for v in V
+    scale_vector(X(v), 2.0);
+  end
+  Y = A * X;
+  V.a = map sum_vectors(Y) to V;
+  scale_vector(V.a, 0.5);
+end

--- a/test/system-matrices-tests.cpp
+++ b/test/system-matrices-tests.cpp
@@ -220,6 +220,44 @@ TEST(system, add_blocked) {
   ASSERT_EQ(3.0, b.get(v2));
 }
 
+TEST(system, add_blocked_inout) {
+  Set V;
+  FieldRef<simit_float> a = V.addField<simit_float>("a");
+  FieldRef<simit_float> b = V.addField<simit_float>("b");
+  ElementRef v0 = V.add();
+  ElementRef v1 = V.add();
+  ElementRef v2 = V.add();
+  b.set(v0, 1.0);
+  b.set(v1, 2.0);
+  b.set(v2, 3.0);
+
+  Set E(V,V);
+  FieldRef<simit_float> e = E.addField<simit_float>("e");
+  ElementRef e0 = E.add(v0,v1);
+  ElementRef e1 = E.add(v1,v2);
+  e.set(e0, 1.0);
+  e.set(e1, 2.0);
+
+  // Compile program and bind arguments
+  Function func = loadFunction(TEST_FILE_NAME, "main");
+  if (!func.defined()) FAIL();
+
+  func.bind("V", &V);
+  func.bind("E", &E);
+
+  func.runSafe();
+
+  // Check that outputs are correct
+  ASSERT_EQ(6.0, a.get(v0));
+  ASSERT_EQ(22.0, a.get(v1));
+  ASSERT_EQ(26.0, a.get(v2));
+
+  // Check that inputs are preserved
+  ASSERT_EQ(1.0, b.get(v0));
+  ASSERT_EQ(2.0, b.get(v1));
+  ASSERT_EQ(3.0, b.get(v2));
+}
+
 TEST(system, add_double_blocked) {
   Set V;
   FieldRef<simit_float> a = V.addField<simit_float>("a");


### PR DESCRIPTION
This set of changes makes a number of adjustments to the inlining heuristics in order to fix a number of compilation bugs:

- Compilation no longer fails if dense system tensors are passed to a function call.
- `inout` attribute now respected even if inout argument is not a variable.